### PR TITLE
Memory Leak Fix

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -26,10 +26,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - name: Check clang-format include
-        uses: jidicula/clang-format-action@v4.13.0
+        uses: jidicula/clang-format-action@v4.18.0
         with:
-          clang-format-version: '18'
+          clang-format-version: '22'
           check-path: ${{ matrix.path }}
 
   prettier:
@@ -39,8 +40,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - name: Check prettier
-        uses: creyD/prettier_action@v4.3
+        uses: creyD/prettier_action@v4.6
         with:
           dry: True
           prettier_options: --check web/*.{js,css,html}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -73,7 +73,7 @@ jobs:
               with:
                 name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
                 path: ./wheelhouse/*.whl
-    
+
     upload_all:
 
         name: Upload if release

--- a/example/basic.cpp
+++ b/example/basic.cpp
@@ -34,8 +34,8 @@ int main(void) {
         const double z = disZ(gen);
         const double e = x + y + z;
 
-        Hit *hit = new Hit({x, y, z}, e);
-        MCHit *mcHit = new MCHit({disX(gen), disY(gen), disZ(gen)}, pdgCodes[disPdg(gen)], e);
+        Hit hit(Position({x, y, z}), e);
+        MCHit mcHit(Position({disX(gen), disY(gen), disZ(gen)}), pdgCodes[disPdg(gen)], e);
 
         HitProperties properties;
 
@@ -57,7 +57,7 @@ int main(void) {
         // Add a continuous property, based on distance from the middle of the detector
         properties[{"Distance", PropertyType::NUMERIC}] = std::abs(x) + std::abs(y) + std::abs(z);
 
-        hit->addProperties(properties);
+        hit.addProperties(properties);
         hits.push_back(hit);
         mcHits.push_back(mcHit);
 
@@ -83,18 +83,18 @@ int main(void) {
             const double z = disZ(gen);
             const double e = x + z;
 
-            Hit *hit = new Hit({x, 0.f, z}, e);
-            hit->setDim(TWO_D);
-            hit->setHitType(views[i]);
+            Hit hit(Position({x, 0.f, z}), e);
+            hit.setDim(TWO_D);
+            hit.setHitType(views[i]);
 
             if (disProb(gen) < 0.1)
-                hit->setWidth("x", 10.f);
+                hit.setWidth("x", 10.f);
 
             hits.push_back(hit);
 
-            MCHit *mcHit = new MCHit({disX(gen), 0.f, disZ(gen)}, pdgCodes[disPdg(gen)], e);
-            mcHit->setDim(TWO_D);
-            mcHit->setHitType(views[i]);
+            MCHit mcHit(Position({disX(gen), 0.f, disZ(gen)}), pdgCodes[disPdg(gen)], e);
+            mcHit.setDim(TWO_D);
+            mcHit.setHitType(views[i]);
             mcHits.push_back(mcHit);
         }
     }

--- a/example/basic.cpp
+++ b/example/basic.cpp
@@ -34,8 +34,8 @@ int main(void) {
         const double z = disZ(gen);
         const double e = x + y + z;
 
-        Hit hit(Position({x, y, z}), e);
-        MCHit mcHit(Position({disX(gen), disY(gen), disZ(gen)}), pdgCodes[disPdg(gen)], e);
+        Hit hit({x, y, z}, e);
+        MCHit mcHit({disX(gen), disY(gen), disZ(gen)}, pdgCodes[disPdg(gen)], e);
 
         HitProperties properties;
 

--- a/example/client.cpp
+++ b/example/client.cpp
@@ -32,8 +32,8 @@ int main(void) {
         const double z = disZ(gen);
         const double e = x + y + z;
 
-        Hit *hit = new Hit({x, y, z}, e);
-        MCHit *mcHit = new MCHit({disX(gen), disY(gen), disZ(gen)}, pdgCodes[disPdg(gen)], e);
+        Hit hit(Position({x, y, z}), e);
+        MCHit mcHit(Position({disX(gen), disY(gen), disZ(gen)}), pdgCodes[disPdg(gen)], e);
 
         std::map<std::string, double> properties;
 
@@ -52,7 +52,7 @@ int main(void) {
         if (z > 1200.0)
             properties["Back"] = 1.0f;
 
-        hit->addProperties(properties);
+        hit.addProperties(properties);
         hits.push_back(hit);
         mcHits.push_back(mcHit);
     }
@@ -68,14 +68,14 @@ int main(void) {
             const double z = disZ(gen);
             const double e = x + z;
 
-            Hit *hit = new Hit({x, 0.f, z}, e);
-            hit->setDim(TWO_D);
-            hit->setHitType(views[i]);
+            Hit hit(Position({x, 0.f, z}), e);
+            hit.setDim(TWO_D);
+            hit.setHitType(views[i]);
             hits.push_back(hit);
 
-            MCHit *mcHit = new MCHit({disX(gen), 0.f, disZ(gen)}, pdgCodes[disPdg(gen)], e);
-            mcHit->setDim(TWO_D);
-            mcHit->setHitType(views[i]);
+            MCHit mcHit(Position({disX(gen), 0.f, disZ(gen)}), pdgCodes[disPdg(gen)], e);
+            mcHit.setDim(TWO_D);
+            mcHit.setHitType(views[i]);
             mcHits.push_back(mcHit);
         }
     }

--- a/example/debugging.cpp
+++ b/example/debugging.cpp
@@ -53,12 +53,11 @@ int main(void) {
             const double z = corner.z + disZ(gen);
             const double e = particles.size() + 1;
 
-            Hit *hit = new Hit({x, y, z}, e);
+            Hit hit(Position({x, y, z}), e);
             particleHits.push_back(hit);
         }
 
-        Particle *particle =
-            new Particle(particleHits, std::to_string(particles.size()), std::to_string(particles.size()));
+        Particle particle(particleHits, std::to_string(particles.size()), std::to_string(particles.size()));
         particles.push_back(particle);
     }
 

--- a/include/hits.h
+++ b/include/hits.h
@@ -144,7 +144,7 @@ class Hit {
     // Optional specific colour for the hit.
     std::string m_colour;
 };
-using Hits = std::vector<Hit *>;
+using Hits = std::vector<Hit>;
 
 inline static void to_json(json &j, const Hits &hits) {
 
@@ -154,13 +154,13 @@ inline static void to_json(json &j, const Hits &hits) {
     }
 
     for (const auto &hit : hits) {
-        j.push_back(*hit);
+        j.push_back(hit);
     }
 }
 
 inline static void from_json(const json &j, Hits &hits) {
     for (const auto &hit : j) {
-        hits.push_back(new Hit(hit));
+        hits.push_back(Hit(hit));
     }
 }
 
@@ -185,7 +185,7 @@ class MCHit : public Hit {
         return this->m_properties.at(key);
     }
 };
-using MCHits = std::vector<MCHit *>;
+using MCHits = std::vector<MCHit>;
 
 inline static void to_json(json &j, const MCHits &hits) {
 
@@ -199,16 +199,16 @@ inline static void to_json(json &j, const MCHits &hits) {
         // Skip hits without a PDG code.
         // This is because technically you can initialize an MCHit without a PDG code.
         // But, if you don't have a PDG code, you're not really an MCHit.
-        if (hit->getPDG() == 0.0)
+        if (hit.getPDG() == 0.0)
             continue;
 
-        j.push_back(*hit);
+        j.push_back(hit);
     }
 }
 
 inline static void from_json(const json &j, MCHits &hits) {
     for (const auto &hit : j) {
-        hits.push_back(new MCHit(hit));
+        hits.push_back(MCHit(hit));
     }
 }
 

--- a/include/image.h
+++ b/include/image.h
@@ -57,7 +57,7 @@ class MonochromeImage {
 };
 
 // TODO: Extend later to include other image types
-using Images = std::vector<MonochromeImage *>;
+using Images = std::vector<MonochromeImage>;
 
 inline static void to_json(json &j, const Images &images) {
 
@@ -67,7 +67,7 @@ inline static void to_json(json &j, const Images &images) {
     }
 
     for (const auto &image : images) {
-        j.push_back(*image);
+        j.push_back(image);
     }
 }
 
@@ -76,7 +76,7 @@ inline static void from_json(const json &j, Images &images) {
         throw std::invalid_argument("Images must be an array!");
 
     for (const auto &jsonImage : j) {
-        images.push_back(new MonochromeImage(jsonImage));
+        images.push_back(MonochromeImage(jsonImage));
     }
 }
 

--- a/include/larsoft_helpers.h
+++ b/include/larsoft_helpers.h
@@ -58,14 +58,14 @@ namespace HepEVD {
 inline geo::WireReadoutGeom const *hepEvdLArSoftWireReadout = nullptr;
 inline detinfo::DetectorPropertiesData const *hepEVDDetProps = nullptr;
 
-using RecoHitMap = std::map<const art::Ptr<recob::Hit>, Hit *>;
+using RecoHitMap = std::map<const art::Ptr<recob::Hit>, std::string>;
 inline RecoHitMap recoHitToEvdHit;
 
-using SpacePointHitMap = std::map<const art::Ptr<recob::SpacePoint>, Hit *>;
+using SpacePointHitMap = std::map<const art::Ptr<recob::SpacePoint>, std::string>;
 inline SpacePointHitMap spacePointToEvdHit;
 
 // Get the current hit maps, such that properties and more can be added
-// to the HepEVD hits.
+// to the HepEVD hits via HepEVDServer::getHitById.
 static RecoHitMap *getHitMap() { return &recoHitToEvdHit; }
 static SpacePointHitMap *getSpacePointMap() { return &spacePointToEvdHit; }
 
@@ -170,7 +170,7 @@ static HitType getHepEVDHitType(geo::View_t geoHitType) {
     }
 }
 
-static Hit *getHitFromRecobHit(const art::Ptr<recob::Hit> &hit) {
+static Hit getHitFromRecobHit(const art::Ptr<recob::Hit> &hit) {
     const auto wireId(hit->WireID());
     const auto view(hit->View());
 
@@ -183,9 +183,9 @@ static Hit *getHitFromRecobHit(const art::Ptr<recob::Hit> &hit) {
     const float z(wirePos.Z() * cos(theta) - wirePos.Y() * sin(theta));
 
     // Now we can make a HepEVD hit.
-    Hit *hepEvdHit = new Hit({x, 0.0, z}, e);
-    hepEvdHit->setDim(getHepEVDHitDimension(view));
-    hepEvdHit->setHitType(getHepEVDHitType(view));
+    Hit hepEvdHit(Position({x, 0.0, z}), e);
+    hepEvdHit.setDim(getHepEVDHitDimension(view));
+    hepEvdHit.setHitType(getHepEVDHitType(view));
 
     return hepEvdHit;
 }
@@ -212,8 +212,8 @@ static void addRecoHits(const art::Event &evt, const std::string hitLabel, const
 
     for (const auto &hit : hitVector) {
         const auto hepEvdHit(getHitFromRecobHit(hit));
+        recoHitToEvdHit.insert({hit, hepEvdHit.getId()});
         hits.push_back(hepEvdHit);
-        recoHitToEvdHit.insert({hit, hepEvdHit});
     }
 
     hepEVDLog("Adding " + std::to_string(hits.size()) + " hits to the HepEVD server.");
@@ -258,9 +258,9 @@ static void showMCParticles(const art::Event &evt, const std::string hitLabel, c
             const art::Ptr<simb::MCParticle> &mcParticle(matchedMCParticles.at(mcParticleIndex));
 
             const auto hepEvdHit(getHitFromRecobHit(hit));
-            MCHit *mcHit = new MCHit(hepEvdHit->getPosition(), mcParticle->PdgCode(), hepEvdHit->getEnergy());
-            mcHit->setDim(hepEvdHit->getDim());
-            mcHit->setHitType(hepEvdHit->getHitType());
+            MCHit mcHit(hepEvdHit.getPosition(), mcParticle->PdgCode(), hepEvdHit.getEnergy());
+            mcHit.setDim(hepEvdHit.getDim());
+            mcHit.setHitType(hepEvdHit.getHitType());
             mcHits.push_back(mcHit);
         }
     }
@@ -319,7 +319,7 @@ static void showMCTruth(const art::Event &evt, const std::string mcTruthLabel) {
     hepEVDServer->setMCTruth(mcTruthString);
 }
 
-static Particle *addParticle(const art::Ptr<recob::PFParticle> &pfp,
+static Particle addParticle(const art::Ptr<recob::PFParticle> &pfp,
                              const std::vector<art::Ptr<recob::SpacePoint>> &spacePoints,
                              const std::vector<art::Ptr<recob::Cluster>> &clusters,
                              const std::vector<art::Ptr<recob::Vertex>> &vertices,
@@ -334,8 +334,8 @@ static Particle *addParticle(const art::Ptr<recob::PFParticle> &pfp,
 
         for (const auto &hit : clusterHits) {
             const auto hepEvdHit(getHitFromRecobHit(hit));
+            recoHitToEvdHit.insert({hit, hepEvdHit.getId()});
             hits.push_back(hepEvdHit);
-            recoHitToEvdHit.insert({hit, hepEvdHit});
         }
     }
 
@@ -347,25 +347,25 @@ static Particle *addParticle(const art::Ptr<recob::PFParticle> &pfp,
         const float y(pos[1]);
         const float z(pos[2]);
 
-        Hit *hepEvdHit = new Hit({x, y, z}, 0.f);
-        hepEvdHit->setDim(HitDimension::THREE_D);
+        Hit hepEvdHit(Position({x, y, z}), 0.f);
+        hepEvdHit.setDim(HitDimension::THREE_D);
 
+        spacePointToEvdHit.insert({spacePoint, hepEvdHit.getId()});
         hits.push_back(hepEvdHit);
-        spacePointToEvdHit.insert({spacePoint, hepEvdHit});
     }
 
     std::string id(getUUID());
-    Particle *particle = new Particle(hits, id, pfp->PdgCode() == 13 ? "Track-like" : "Shower-like");
+    Particle particle(hits, id, pfp->PdgCode() == 13 ? "Track-like" : "Shower-like");
 
     // Set the interaction type, based on the parent PFP.
     const auto pdgCode(std::abs(pfp->PdgCode()));
     const auto isNeutrino(pfp->IsPrimary() && (pdgCode == 12 || pdgCode == 14 || pdgCode == 16));
-    particle->setPrimary(pfp->IsPrimary());
+    particle.setPrimary(pfp->IsPrimary());
 
     if (isNeutrino)
-        particle->setInteractionType(InteractionType::NEUTRINO);
+        particle.setInteractionType(InteractionType::NEUTRINO);
     else
-        particle->setInteractionType(InteractionType::COSMIC);
+        particle.setInteractionType(InteractionType::COSMIC);
 
     Markers vertexMarkers;
 
@@ -385,7 +385,7 @@ static Particle *addParticle(const art::Ptr<recob::PFParticle> &pfp,
         // TODO: 2D vertex markers.
     }
 
-    particle->setVertices(vertexMarkers);
+    particle.setVertices(vertexMarkers);
 
     return particle;
 }
@@ -402,7 +402,7 @@ static void addPFPs(const art::Event &evt, const std::string pfpModuleLabel, con
     hepEVDDetProps = &detProps;
 
     Particles particles;
-    std::map<const art::Ptr<recob::PFParticle>, Particle *> pfpToParticleMap;
+    std::map<const art::Ptr<recob::PFParticle>, size_t> pfpToParticleMap;
 
     art::Handle<std::vector<recob::PFParticle>> pfpHandle;
     std::vector<art::Ptr<recob::PFParticle>> particleVector;
@@ -450,7 +450,7 @@ static void addPFPs(const art::Event &evt, const std::string pfpModuleLabel, con
 
         const auto particle = addParticle(pfp, pfpSpacePoints, clusters, vertices, clusterHitAssoc, label);
         particles.push_back(particle);
-        pfpToParticleMap.insert({pfp, particle});
+        pfpToParticleMap.insert({pfp, particles.size() - 1});
     }
 
     // Finally, link up the parent/child relationships.
@@ -465,11 +465,11 @@ static void addPFPs(const art::Event &evt, const std::string pfpModuleLabel, con
         if (childPfp->IsPrimary())
             continue; // Skip primary particles, as they have no parent.
 
-        const auto childParticle(pfpToParticleMap[childPfp]);
-        const auto parentParticle(pfpToParticleMap[parentPfp]);
+        const auto childParticleIndex(pfpToParticleMap[childPfp]);
+        const auto parentParticleIndex(pfpToParticleMap[parentPfp]);
 
-        parentParticle->addChild(childParticle->getID());
-        childParticle->setParentID(parentParticle->getID());
+        particles[parentParticleIndex].addChild(particles[childParticleIndex].getID());
+        particles[childParticleIndex].setParentID(particles[parentParticleIndex].getID());
     }
 
     hepEVDLog("Adding " + std::to_string(particles.size()) + " particles to the HepEVD server.");

--- a/include/larsoft_helpers.h
+++ b/include/larsoft_helpers.h
@@ -320,10 +320,10 @@ static void showMCTruth(const art::Event &evt, const std::string mcTruthLabel) {
 }
 
 static Particle addParticle(const art::Ptr<recob::PFParticle> &pfp,
-                             const std::vector<art::Ptr<recob::SpacePoint>> &spacePoints,
-                             const std::vector<art::Ptr<recob::Cluster>> &clusters,
-                             const std::vector<art::Ptr<recob::Vertex>> &vertices,
-                             const art::FindManyP<recob::Hit> &clusterHitAssoc, const std::string label = "") {
+                            const std::vector<art::Ptr<recob::SpacePoint>> &spacePoints,
+                            const std::vector<art::Ptr<recob::Cluster>> &clusters,
+                            const std::vector<art::Ptr<recob::Vertex>> &vertices,
+                            const art::FindManyP<recob::Hit> &clusterHitAssoc, const std::string label = "") {
 
     Hits hits;
 

--- a/include/pandora_helpers.h
+++ b/include/pandora_helpers.h
@@ -311,7 +311,7 @@ static void showMC(const pandora::Algorithm &pAlgorithm, const std::string &list
 
             const auto pos = caloHit->GetPositionVector();
             MCHit mcHit(Position({pos.GetX(), pos.GetY(), pos.GetZ()}), mcParticle->GetParticleId(),
-                       caloHit->GetMipEquivalentEnergy());
+                        caloHit->GetMipEquivalentEnergy());
 
             mcHit.setDim(getHepEVDHitDimension(caloHit->GetHitType()));
             mcHit.setHitType(getHepEVDHitType(caloHit->GetHitType()));
@@ -383,7 +383,7 @@ static void getAllCaloHits(const pandora::ParticleFlowObject *pPfo, pandora::Cal
 }
 
 static Particle addParticle(const pandora::Pandora &pPandora, const pandora::ParticleFlowObject *pPfo,
-                             std::string label = "") {
+                            std::string label = "") {
 
     Hits hits;
     pandora::CaloHitList caloHitList;

--- a/include/pandora_helpers.h
+++ b/include/pandora_helpers.h
@@ -50,11 +50,11 @@ typedef std::unordered_map<const pandora::Cluster *, unsigned int> ClusterToSlic
 
 namespace HepEVD {
 
-using PandoraHitMap = std::map<const pandora::CaloHit *, Hit *>;
+using PandoraHitMap = std::map<const pandora::CaloHit *, std::string>;
 inline PandoraHitMap caloHitToEvdHit;
 
 // Get the current hit map, such that properties and more can be added
-// to the HepEVD hits.
+// to the HepEVD hits via HepEVDServer::getHitById.
 static PandoraHitMap *getHitMap() { return &caloHitToEvdHit; }
 
 // Set the HepEVD geometry by pulling the relevant information from the
@@ -152,19 +152,19 @@ static HepEVD::Hits getHits(const pandora::CaloHitList *caloHits, std::string la
 
     for (const pandora::CaloHit *const pCaloHit : *caloHits) {
         const auto pos = pCaloHit->GetPositionVector();
-        Hit *hit = new Hit({pos.GetX(), pos.GetY(), pos.GetZ()}, pCaloHit->GetMipEquivalentEnergy());
+        Hit hit(Position({pos.GetX(), pos.GetY(), pos.GetZ()}), pCaloHit->GetMipEquivalentEnergy());
 
         if (label != "")
-            hit->setLabel(label);
+            hit.setLabel(label);
 
-        hit->setDim(getHepEVDHitDimension(pCaloHit->GetHitType()));
-        hit->setHitType(getHepEVDHitType(pCaloHit->GetHitType()));
+        hit.setDim(getHepEVDHitDimension(pCaloHit->GetHitType()));
+        hit.setHitType(getHepEVDHitType(pCaloHit->GetHitType()));
 
         if (pCaloHit->GetCellSize1() > 1)
-            hit->setWidth("x", pCaloHit->GetCellSize1());
+            hit.setWidth("x", pCaloHit->GetCellSize1());
 
+        caloHitToEvdHit.insert({pCaloHit, hit.getId()});
         hits.push_back(hit);
-        caloHitToEvdHit.insert({pCaloHit, hit});
     }
 
     return hits;
@@ -197,7 +197,7 @@ static void addClusters(const pandora::ClusterList *clusters, std::string label 
         pandora::CaloHitList clusterCaloHits;
         HepEVD::getAllCaloHits(pCluster, clusterCaloHits);
 
-        auto clusterParticle = new Particle(HepEVD::getHits(&clusterCaloHits, label), getUUID());
+        auto clusterParticle = Particle(HepEVD::getHits(&clusterCaloHits, label), getUUID());
         particles.push_back(clusterParticle);
     }
 
@@ -215,7 +215,8 @@ static void addClusterProperties(const pandora::Cluster *cluster, std::map<std::
             if (caloHitToEvdHit.count(caloHit) == 0)
                 continue;
 
-            caloHitToEvdHit[caloHit]->addProperties(props);
+            if (auto *hit = hepEVDServer->getHitById(caloHitToEvdHit[caloHit]))
+                hit->addProperties(props);
         }
     }
 }
@@ -238,7 +239,7 @@ static void addSlices(const SliceList *slices, const std::string label = "") {
         auto wHits = HepEVD::getHits(&slice.m_caloHitListW, label);
         sliceHits.insert(sliceHits.end(), wHits.begin(), wHits.end());
 
-        auto sliceParticle = new Particle(sliceHits, getUUID());
+        auto sliceParticle = Particle(sliceHits, getUUID());
         particles.push_back(sliceParticle);
     }
 
@@ -309,11 +310,11 @@ static void showMC(const pandora::Algorithm &pAlgorithm, const std::string &list
         for (auto const caloHit : caloHitList) {
 
             const auto pos = caloHit->GetPositionVector();
-            MCHit *mcHit = new MCHit({pos.GetX(), pos.GetY(), pos.GetZ()}, mcParticle->GetParticleId(),
-                                     caloHit->GetMipEquivalentEnergy());
+            MCHit mcHit(Position({pos.GetX(), pos.GetY(), pos.GetZ()}), mcParticle->GetParticleId(),
+                       caloHit->GetMipEquivalentEnergy());
 
-            mcHit->setDim(getHepEVDHitDimension(caloHit->GetHitType()));
-            mcHit->setHitType(getHepEVDHitType(caloHit->GetHitType()));
+            mcHit.setDim(getHepEVDHitDimension(caloHit->GetHitType()));
+            mcHit.setHitType(getHepEVDHitType(caloHit->GetHitType()));
 
             mcHits.push_back(mcHit);
         }
@@ -381,7 +382,7 @@ static void getAllCaloHits(const pandora::ParticleFlowObject *pPfo, pandora::Cal
     }
 }
 
-static Particle *addParticle(const pandora::Pandora &pPandora, const pandora::ParticleFlowObject *pPfo,
+static Particle addParticle(const pandora::Pandora &pPandora, const pandora::ParticleFlowObject *pPfo,
                              std::string label = "") {
 
     Hits hits;
@@ -390,20 +391,20 @@ static Particle *addParticle(const pandora::Pandora &pPandora, const pandora::Pa
 
     for (const pandora::CaloHit *const pCaloHit : caloHitList) {
         const auto pos = pCaloHit->GetPositionVector();
-        Hit *hit = new Hit({pos.GetX(), pos.GetY(), pos.GetZ()}, pCaloHit->GetMipEquivalentEnergy());
+        Hit hit(Position({pos.GetX(), pos.GetY(), pos.GetZ()}), pCaloHit->GetMipEquivalentEnergy());
 
         if (label != "")
-            hit->setLabel(label);
+            hit.setLabel(label);
 
-        hit->setDim(getHepEVDHitDimension(pCaloHit->GetHitType()));
-        hit->setHitType(getHepEVDHitType(pCaloHit->GetHitType()));
+        hit.setDim(getHepEVDHitDimension(pCaloHit->GetHitType()));
+        hit.setHitType(getHepEVDHitType(pCaloHit->GetHitType()));
 
+        caloHitToEvdHit.insert({pCaloHit, hit.getId()});
         hits.push_back(hit);
-        caloHitToEvdHit.insert({pCaloHit, hit});
     }
 
     std::string id(getUUID());
-    Particle *particle = new Particle(hits, id, pPfo->GetParticleId() == 13 ? "Track-like" : "Shower-like");
+    Particle particle(hits, id, pPfo->GetParticleId() == 13 ? "Track-like" : "Shower-like");
 
     const auto parentPfo(lar_content::LArPfoHelper::GetParentPfo(pPfo));
     const bool isNeutrinoOrFinalState(lar_content::LArPfoHelper::IsNeutrino(pPfo) ||
@@ -411,9 +412,9 @@ static Particle *addParticle(const pandora::Pandora &pPandora, const pandora::Pa
     const bool isNeutrinoChild(lar_content::LArPfoHelper::IsNeutrino(parentPfo));
 
     if (isNeutrinoOrFinalState || isNeutrinoChild)
-        particle->setInteractionType(InteractionType::NEUTRINO);
+        particle.setInteractionType(InteractionType::NEUTRINO);
     else
-        particle->setInteractionType(InteractionType::COSMIC);
+        particle.setInteractionType(InteractionType::COSMIC);
 
     const pandora::Vertex *vertex(nullptr);
 
@@ -427,7 +428,7 @@ static Particle *addParticle(const pandora::Pandora &pPandora, const pandora::Pa
 
     Markers vertices;
     Point recoVertex3D({vertex->GetPosition().GetX(), vertex->GetPosition().GetY(), vertex->GetPosition().GetZ()});
-    if (particle->getInteractionType() == InteractionType::COSMIC)
+    if (particle.getInteractionType() == InteractionType::COSMIC)
         recoVertex3D.setColour("yellow");
     vertices.push_back(recoVertex3D);
 
@@ -438,12 +439,12 @@ static Particle *addParticle(const pandora::Pandora &pPandora, const pandora::Pa
             lar_content::LArGeometryHelper::ProjectPosition(pPandora, vertex->GetPosition(), view);
         Point recoVertex2D({vertex2D.GetX(), vertex2D.GetY(), vertex2D.GetZ()}, HitDimension::TWO_D,
                            getHepEVDHitType(view));
-        if (particle->getInteractionType() == InteractionType::COSMIC)
+        if (particle.getInteractionType() == InteractionType::COSMIC)
             recoVertex2D.setColour("yellow");
         vertices.push_back(recoVertex2D);
     }
 
-    particle->setVertices(vertices);
+    particle.setVertices(vertices);
 
     return particle;
 }
@@ -457,13 +458,13 @@ static void addPFOs(const pandora::Pandora &pPandora, const pandora::PfoList *pP
         return;
 
     Particles particles;
-    std::map<const pandora::ParticleFlowObject *, Particle *> pfoToParticleMap;
+    std::map<const pandora::ParticleFlowObject *, size_t> pfoToParticleMap;
 
     // First, get a HepEVD::Particle for every Pandora::PFO.
     for (const pandora::ParticleFlowObject *const pPfo : *pPfoList) {
         const auto particle = addParticle(pPandora, pPfo, label);
         particles.push_back(particle);
-        pfoToParticleMap.insert({pPfo, particle});
+        pfoToParticleMap.insert({pPfo, particles.size() - 1});
     }
 
     // Now, we can add the parent/child relationships.
@@ -489,7 +490,7 @@ static void addPFOs(const pandora::Pandora &pPandora, const pandora::PfoList *pP
             continue;
 
         const auto pPfo = parentChildPair.first;
-        const auto parent = pfoToParticleMap.at(pPfo);
+        const auto parentIndex = pfoToParticleMap.at(pPfo);
 
         for (const auto childPfo : parentChildPair.second) {
 
@@ -497,16 +498,16 @@ static void addPFOs(const pandora::Pandora &pPandora, const pandora::PfoList *pP
             if (pfoToParticleMap.count(childPfo) == 0) {
                 const auto particle = addParticle(pPandora, childPfo, label);
                 particles.push_back(particle);
-                pfoToParticleMap.insert({childPfo, particle});
+                pfoToParticleMap.insert({childPfo, particles.size() - 1});
             }
 
             if (pPfo == childPfo)
                 continue;
 
-            const auto child = pfoToParticleMap.at(childPfo);
+            const auto childIndex = pfoToParticleMap.at(childPfo);
 
-            parent->addChild(child->getID());
-            child->setParentID(parent->getID());
+            particles[parentIndex].addChild(particles[childIndex].getID());
+            particles[childIndex].setParentID(particles[parentIndex].getID());
         }
     }
 
@@ -543,7 +544,7 @@ template <typename T> static void addDLTensorImage(const at::Tensor inputImageTe
         imageVector.push_back(row);
     }
 
-    MonochromeImage *image = new MonochromeImage(imageVector, name);
+    MonochromeImage image(imageVector, name);
 
     hepEVDLog("Adding " + name + " image to the HepEVD server.");
     hepEVDServer->addImages({image});

--- a/include/particle.h
+++ b/include/particle.h
@@ -40,13 +40,16 @@ class Particle {
     double getEnergy() const {
         double energy = 0.0;
         for (const auto &hit : this->m_hits)
-            energy += hit->getEnergy();
+            energy += hit.getEnergy();
         return energy;
     }
 
     unsigned int getNHits() const { return this->m_hits.size(); }
     std::string getLabel() const { return this->m_label; }
     std::string getID() const { return this->m_id; }
+
+    Hits &getHits() { return this->m_hits; }
+    const Hits &getHits() const { return this->m_hits; }
 
     void setVertices(const Markers &vertices) {
         // Check that the markers are all Point-type.
@@ -88,7 +91,7 @@ class Particle {
         writer.Key("hits");
         writer.StartArray();
         for (const auto &hit : m_hits) {
-            hit->writeJson(writer);
+            hit.writeJson(writer);
         }
         writer.EndArray();
 
@@ -169,7 +172,7 @@ class Particle {
     std::string m_parentID;
     std::vector<std::string> m_childIDs;
 };
-using Particles = std::vector<Particle *>;
+using Particles = std::vector<Particle>;
 
 inline static void to_json(json &j, const Particles &particles) {
 
@@ -179,13 +182,13 @@ inline static void to_json(json &j, const Particles &particles) {
     }
 
     for (const auto &particle : particles) {
-        j.push_back(*particle);
+        j.push_back(particle);
     }
 }
 
 inline static void from_json(const json &j, Particles &particles) {
     for (const auto &particle : j) {
-        particles.push_back(new Particle(particle));
+        particles.push_back(Particle(particle));
     }
 }
 

--- a/include/server.h
+++ b/include/server.h
@@ -129,6 +129,10 @@ class HepEVDServer {
     }
     Hits getHits() { return this->getState()->m_hits; }
 
+    // Look up a hit that was already added (directly, or via a Particle) by its ID,
+    // so callers can attach properties to it after the fact without holding a pointer.
+    Hit *getHitById(const std::string &id) { return this->getState()->getHitById(id); }
+
     bool addMarkers(const Markers &inputMarkers) {
 
         if (this->getState()->m_markers.size() == 0) {

--- a/include/state.h
+++ b/include/state.h
@@ -18,6 +18,8 @@
 #include "extern/json.hpp"
 using json = nlohmann::json;
 
+#include <unordered_map>
+
 namespace HepEVD {
 
 // Top level state object, that contains everything about the current state of the
@@ -44,8 +46,40 @@ class EventState {
         m_markers.clear();
         m_images.clear();
 
+        m_hitIdCache.clear();
+        m_hitIdCacheSize = 0;
+
         if (resetMCTruth)
             m_mcTruth = "";
+    }
+
+    // Find a hit that was previously added (either directly, or as part of a
+    // Particle), by its ID, so properties can be attached to it after the
+    // fact. Returns nullptr if no such hit exists.
+    //
+    // The lookup cache is rebuilt whenever the total number of hits changes,
+    // rather than on every mutation, since hits/particles are effectively
+    // append-only between calls to clear().
+    Hit *getHitById(const std::string &id) {
+        size_t currentSize = m_hits.size();
+        for (const auto &particle : m_particles)
+            currentSize += particle.getHits().size();
+
+        if (currentSize != m_hitIdCacheSize) {
+            m_hitIdCache.clear();
+
+            for (auto &hit : m_hits)
+                m_hitIdCache[hit.getId()] = &hit;
+
+            for (auto &particle : m_particles)
+                for (auto &hit : particle.getHits())
+                    m_hitIdCache[hit.getId()] = &hit;
+
+            m_hitIdCacheSize = currentSize;
+        }
+
+        const auto it = m_hitIdCache.find(id);
+        return it == m_hitIdCache.end() ? nullptr : it->second;
     }
 
     // Only need a to JSON method, as we don't need to read in the state.
@@ -67,6 +101,10 @@ class EventState {
     Markers m_markers;
     Images m_images;
     std::string m_mcTruth;
+
+  private:
+    std::unordered_map<std::string, Hit *> m_hitIdCache;
+    size_t m_hitIdCacheSize = 0;
 };
 
 using EventStates = std::map<int, EventState>;

--- a/include/traccc_helpers.h
+++ b/include/traccc_helpers.h
@@ -116,12 +116,12 @@ static void addSpacepoints(const traccc::edm::spacepoint_collection::const_view 
 
     for (unsigned int i = 0; i < spacePointsView.size(); i++) {
         const auto spacePoint = spacePointsView.at(i);
-        Hit *hit = new Hit({spacePoint.x(), spacePoint.y(), spacePoint.z()}, 0.0);
+        Hit hit(Position({spacePoint.x(), spacePoint.y(), spacePoint.z()}), 0.0);
 
         if (label != "")
-            hit->setLabel(label);
+            hit.setLabel(label);
 
-        hit->setDim(THREE_D);
+        hit.setDim(THREE_D);
         hits.push_back(hit);
     }
 
@@ -148,12 +148,12 @@ static void addSeeds(const traccc::edm::seed_collection::const_view &seeds,
 
         for (const auto &index : {seed.bottom_index(), seed.middle_index(), seed.top_index()}) {
             const auto spacePoint = spacePointsView.at(index);
-            Hit *hit = new Hit({spacePoint.x(), spacePoint.y(), spacePoint.z()}, 0.0);
+            Hit hit(Position({spacePoint.x(), spacePoint.y(), spacePoint.z()}), 0.0);
             hits.push_back(hit);
         }
 
         std::string id = getUUID();
-        Particle *particle = new Particle(hits, id, label);
+        Particle particle(hits, id, label);
 
         hepSeeds.push_back(particle);
     }
@@ -203,14 +203,14 @@ addTrackCandidates(const traccc::edm::track_candidate_collection<traccc::default
             const auto global = surface.local_to_global({}, m.local, {});
 
             // Create a hit object for this measurement.
-            Hit *hit = new Hit({global[0], global[1], global[2]}, 0.0);
+            Hit hit(Position({global[0], global[1], global[2]}), 0.0);
             hits.push_back(hit);
         }
 
         // Create a particle object for this track candidate.
         std::string id = getUUID();
-        Particle *particle = new Particle(hits, id, label);
-        particle->setRenderType(RenderType::TRACK);
+        Particle particle(hits, id, label);
+        particle.setRenderType(RenderType::TRACK);
 
         // Add the particle to the list of particles to be added to the server.
         hepTracks.push_back(particle);
@@ -252,14 +252,14 @@ static void addTracks(const traccc::track_state_container_types::const_view &tra
             const auto global = surface.local_to_global({}, m.local, {});
 
             // Create a hit object for this measurement.
-            Hit *hit = new Hit({global[0], global[1], global[2]}, 0.0);
+            Hit hit(Position({global[0], global[1], global[2]}), 0.0);
             hits.push_back(hit);
         }
 
         // Create a particle object for this track candidate.
         std::string id = getUUID();
-        Particle *particle = new Particle(hits, id, label);
-        particle->setRenderType(RenderType::TRACK);
+        Particle particle(hits, id, label);
+        particle.setRenderType(RenderType::TRACK);
 
         // Add the particle to the list of particles to be added to the server.
         hepTracks.push_back(particle);

--- a/include/utils.h
+++ b/include/utils.h
@@ -21,6 +21,7 @@ using json = nlohmann::json;
 #include <iterator>
 #include <numeric>
 #include <ostream>
+#include <iostream>
 #include <random>
 #include <sstream>
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -319,8 +319,8 @@ template <typename Container> std::string parallel_to_json_array(const Container
 
         writer.StartArray();
         for (auto it = begin; it != end; ++it) {
-            const auto *item_ptr = *it;
-            item_ptr->writeJson(writer);
+            const auto &item = *it;
+            item.writeJson(writer);
         }
         writer.EndArray();
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -18,10 +18,10 @@ using json = nlohmann::json;
 #include <array>
 #include <functional>
 #include <future>
+#include <iostream>
 #include <iterator>
 #include <numeric>
 #include <ostream>
-#include <iostream>
 #include <random>
 #include <sstream>
 

--- a/python_bindings/src/hits.cpp
+++ b/python_bindings/src/hits.cpp
@@ -25,7 +25,7 @@ namespace nb = nanobind;
 namespace HepEVD_py {
 
 template <typename T>
-T *processHitRow(const double *rowData, bool includesDimension, bool includesView, const std::string &label) {
+T processHitRow(const double *rowData, bool includesDimension, bool includesView, const std::string &label) {
     int idx = 0;
     double x = rowData[idx++];
     double y = rowData[idx++];
@@ -36,23 +36,25 @@ T *processHitRow(const double *rowData, bool includesDimension, bool includesVie
     double dimension = includesDimension ? rowData[idx++] : -1.0;
     double view = includesView ? rowData[idx++] : -1.0;
 
-    T *hit(nullptr);
+    T hit = [&]() {
+        if constexpr (std::is_same_v<T, HepEVD::MCHit>) {
+            return T(HepEVD::Position({x, y, z}), pdgCode, energy);
+        } else {
+            return T(HepEVD::Position({x, y, z}), energy);
+        }
+    }();
 
-    if constexpr (std::is_same_v<T, HepEVD::MCHit>) {
-        hit = new T(HepEVD::Position({x, y, z}), pdgCode, energy);
-    } else {
-        hit = new T(HepEVD::Position({x, y, z}), energy);
-        pythonHitMap[std::make_tuple(x, y, z, energy)] = hit;
-    }
+    if constexpr (!std::is_same_v<T, HepEVD::MCHit>)
+        pythonHitMap[std::make_tuple(x, y, z, energy)] = hit.getId();
 
     if (includesDimension)
-        hit->setDim(static_cast<HepEVD::HitDimension>(dimension));
+        hit.setDim(static_cast<HepEVD::HitDimension>(dimension));
 
     if (includesView)
-        hit->setHitType(static_cast<HepEVD::HitType>(view));
+        hit.setHitType(static_cast<HepEVD::HitType>(view));
 
     if (label != "")
-        hit->setLabel(label);
+        hit.setLabel(label);
 
     return hit;
 }
@@ -93,7 +95,7 @@ template <typename T> void add_hits(nb::handle hits, std::string label) {
     int rows = arraySize[0];
     int cols = arraySize[1];
 
-    std::vector<T *> hepEVDHits;
+    std::vector<T> hepEVDHits;
     hepEVDHits.reserve(rows);
 
     // If it's an ndarray, process all data at once
@@ -143,7 +145,10 @@ void set_hit_properties(nb::handle hit, nb::dict properties) {
     if (!pythonHitMap.count(inputHit))
         throw std::runtime_error("HepEVD: No hit exists with the given position");
 
-    HepEVD::Hit *hepEVDHit = pythonHitMap[inputHit];
+    HepEVD::Hit *hepEVDHit = HepEVD::getServer()->getHitById(pythonHitMap[inputHit]);
+
+    if (!hepEVDHit)
+        throw std::runtime_error("HepEVD: Hit no longer exists (was the server reset?)");
 
     for (auto item : properties) {
         std::string key = nb::cast<std::string>(item.first);

--- a/python_bindings/src/include/global.hpp
+++ b/python_bindings/src/include/global.hpp
@@ -19,7 +19,7 @@ namespace HepEVD_py {
 
 // Map from Python types to HepEVD types.
 using RawHit = std::tuple<double, double, double, double>;
-using PythonHitMap = std::map<RawHit, HepEVD::Hit *>;
+using PythonHitMap = std::map<RawHit, std::string>;
 inline PythonHitMap pythonHitMap;
 
 /**

--- a/python_bindings/src/particles.cpp
+++ b/python_bindings/src/particles.cpp
@@ -89,22 +89,22 @@ void add_particles(nb::handle particles, std::string label) {
             double dimension = includesView ? hitData[idx++] : -1.0;
             double view = includesView ? hitData[idx++] : -1.0;
 
-            HepEVD::Hit *hepHit = new HepEVD::Hit({x, y, z}, energy);
+            HepEVD::Hit hepHit(HepEVD::Position({x, y, z}), energy);
 
             if (includesView) {
-                hepHit->setHitType(static_cast<HepEVD::HitType>(view));
-                hepHit->setDim(static_cast<HepEVD::HitDimension>(dimension));
+                hepHit.setHitType(static_cast<HepEVD::HitType>(view));
+                hepHit.setDim(static_cast<HepEVD::HitDimension>(dimension));
             }
 
             if (!label.empty())
-                hepHit->setLabel(label);
+                hepHit.setLabel(label);
 
             particleHits.push_back(hepHit);
         }
 
         // Now, we can create a HepEVD particle object.
         std::string id(HepEVD::getUUID());
-        HepEVD::Particle *hepParticle = new HepEVD::Particle(particleHits, id, label);
+        HepEVD::Particle hepParticle(particleHits, id, label);
         hepEVDParticles.push_back(hepParticle);
     }
 


### PR DESCRIPTION
This should help with preventing memory leaks - Hits are passed in by value, such that if a user forgets to clean up memory, it won't leak memory now.

Required slightly changing the interface to stop taking pointers, and also updating the helpers to look for hits via their UUID, not just matching pointers.